### PR TITLE
Fall 2024 Shopify SWE Internship OA Solution - Amy Zhuo

### DIFF
--- a/javascript/solution.js
+++ b/javascript/solution.js
@@ -16,6 +16,7 @@ const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 function generateKeyTable(key) {
   // ensure key is all uppercase and contains only unique letter characters
   //  note: see Pull Request descrition for "alternate key generation methods"
+  //  QUESTION: if 'X' is used to pad digrams, should it be usable in the key?
   key = [...new Set(key.toUpperCase().replace(/[^A-Z]/g, ""))].join("");
 
   // ensure the table is completed with remaining unique letters (not in the key)
@@ -79,10 +80,7 @@ function decryptCipherText(cipherText, key) {
   }
 
   // ensure decrypted string is: all uppercase & contains only letter characters & excludes 'X'
-  plainText = plainText
-    .toUpperCase()
-    .replace(/[^A-Z]/g, "")
-    .replace(/X/g, "");
+  plainText = plainText.toUpperCase().replace(/[^A-Z]|X/g, "");
 
   return plainText;
 }

--- a/javascript/solution.js
+++ b/javascript/solution.js
@@ -1,30 +1,3 @@
-/* 
-This solution will decrypt the cipherText into plainText in two parts:
-
-First, generating the 5*5 keytable.
-  - the table must not contain duplicate letters or non-letter characters
-  - all letters in the table must be uppercase
-
-Then, decrypt the cipherText using the keytable.
-The algorithm used is as follows:
-  For each digram, obtain the keyTable row and col of the 2 letters indiivdually.
-  - if (col1 === col2), replace each letter with the letter ABOVE it (wrapping index 0 --> 4)
-      - ie. letter1: keyTable[row1][(col1 + 4) % 5] & letter2: keyTable[row2][(col2 + 4) % 5]
-  - if (row1 === row2), replace each letter with the letter to its LEFT (wrapping index 0 --> 4)
-      - ie. letter1: keyTable[(row1 + 4) % 5][col1] & letter2: keyTable[(row2 + 4) % 5][col2]
-  - if neither, swap the columns of the 2 letters
-      - ie. letter1: keyTable[row1][col2] & letter2: keyTable[row2][col1]
-
-
-Rationale for representing the 5x5 keytable as a 2D vs. 1D array:
-  - 2D array is more intuitive to visualize and access
-  - Does not rely on math (ie. modulus) to denote element indices
-  - 2D array is more difficult to populate when generating keytable (looping vs. appending via .push())
-
-  However, 2D array was chosen since the keytable is generated only 
-  once yet indexed multiple times.
-*/
-
 // HELPER FUNCTIONS:
 function getLetterRowCol(letter, keyTable) {
   for (row = 0; row < keyTable.length; row++) {
@@ -42,10 +15,7 @@ const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 function generateKeyTable(key) {
   // ensure key is all uppercase and contains only unique letter characters
-  //  note: see Pull Request descrition for alternative ways to handle this: "alternate key generation methods"
-  //  note: an alternative way to uppercase all letters is to manipulate the ASCII
-  //  note: an alternative way to remove duplictes is to loop through and compare consecutive letters
-  //  note: an alternative way to regex-removing non-letter characters is to check the ASCII letter range
+  //  note: see Pull Request descrition for "alternate key generation methods"
   key = [...new Set(key.toUpperCase().replace(/[^A-Z]/g, ""))].join("");
 
   // ensure the table is completed with remaining unique letters (not in the key)

--- a/javascript/solution.js
+++ b/javascript/solution.js
@@ -1,0 +1,131 @@
+/* 
+This solution will decrypt the cipherText into plainText in two parts:
+
+First, generating the 5*5 keytable.
+  - the table must not contain duplicate letters or non-letter characters
+  - all letters in the table must be uppercase
+
+Then, decrypt the cipherText using the keytable.
+The algorithm used is as follows:
+  For each digram, obtain the keyTable row and col of the 2 letters indiivdually.
+  - if (col1 === col2), replace each letter with the letter ABOVE it (wrapping index 0 --> 4)
+      - ie. letter1: keyTable[row1][(col1 + 4) % 5] & letter2: keyTable[row2][(col2 + 4) % 5]
+  - if (row1 === row2), replace each letter with the letter to its LEFT (wrapping index 0 --> 4)
+      - ie. letter1: keyTable[(row1 + 4) % 5][col1] & letter2: keyTable[(row2 + 4) % 5][col2]
+  - if neither, swap the columns of the 2 letters
+      - ie. letter1: keyTable[row1][col2] & letter2: keyTable[row2][col1]
+
+
+Rationale for representing the 5x5 keytable as a 2D vs. 1D array:
+  - 2D array is more intuitive to visualize and access
+  - Does not rely on math (ie. modulus) to denote element indices
+  - 2D array is more difficult to populate when generating keytable (looping vs. appending via .push())
+
+  However, 2D array was chosen since the keytable is generated only 
+  once yet indexed multiple times.
+*/
+
+// HELPER FUNCTIONS:
+function getLetterRowCol(letter, keyTable) {
+  for (row = 0; row < keyTable.length; row++) {
+    for (col = 0; col < keyTable[row].length; col++) {
+      if (keyTable[row][col] === letter) {
+        return [row, col];
+      }
+    }
+  }
+  return [null, null];
+}
+
+// PART 1: GENERATE THE 5*5 KEYTABLE
+const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+function generateKeyTable(key) {
+  // ensure key is all uppercase and contains only unique letter characters
+  //  note: see Pull Request descrition for alternative ways to handle this: "alternate key generation methods"
+  //  note: an alternative way to uppercase all letters is to manipulate the ASCII
+  //  note: an alternative way to remove duplictes is to loop through and compare consecutive letters
+  //  note: an alternative way to regex-removing non-letter characters is to check the ASCII letter range
+  key = [...new Set(key.toUpperCase().replace(/[^A-Z]/g, ""))].join("");
+
+  // ensure the table is completed with remaining unique letters (not in the key)
+  let remainingUniqueLetters = alphabet;
+  for (let i = 0; i < key.length; i++) {
+    remainingUniqueLetters = remainingUniqueLetters.replace(key[i], "");
+  }
+
+  // remove one more letter (for a total of 25 letters)
+  const removableLetters = ["J", "Q", "I"];
+  for (let letter of removableLetters) {
+    if (remainingUniqueLetters.includes(letter)) {
+      remainingUniqueLetters = remainingUniqueLetters.replace(letter, "");
+      break;
+    }
+  }
+
+  // populate the 5x5 keytable (2D array) with key and remainingUniqueLetters
+  // [0, 1, 2, 3, 4, 5, ... , 23, 24] ==>
+  // [ [0, 1, 2, 3, 4],
+  //   [5, 6, 7, 8, 9],
+  //   [10, 11, 12, 13, 14],
+  //   [15, 16, 17, 18, 19],
+  //   [20, 21, 22, 23, 24] ];
+  let temporaryKeyTable = key
+    .split("")
+    .concat(remainingUniqueLetters.split(""));
+  let keyTable = [];
+  for (let i = 0; i < temporaryKeyTable.length; i += 5) {
+    keyTable.push(temporaryKeyTable.slice(i, i + 5));
+  }
+
+  return keyTable;
+}
+
+// PART 2: DECRYPT THE CIPHERTEXT USING THE KEYTABLE
+function decryptCipherText(cipherText, key) {
+  cipherText = cipherText.toUpperCase();
+  const keyTable = generateKeyTable(key);
+  let plainText = "";
+
+  // note: the cipherText will always have an even number of letters dy design
+  for (let digramIndex = 0; digramIndex < cipherText.length; digramIndex += 2) {
+    let letter1 = cipherText[digramIndex];
+    let letter2 = cipherText[digramIndex + 1];
+
+    let [row1, col1] = getLetterRowCol(letter1, keyTable);
+    let [row2, col2] = getLetterRowCol(letter2, keyTable);
+
+    // apply the decryption procedure as described in the PR description
+    if (col1 === col2) {
+      plainText += keyTable[(row1 + 4) % 5][col1];
+      plainText += keyTable[(row2 + 4) % 5][col2];
+    } else if (row1 === row2) {
+      plainText += keyTable[row1][(col1 + 4) % 5];
+      plainText += keyTable[row2][(col2 + 4) % 5];
+    } else {
+      plainText += keyTable[row1][col2];
+      plainText += keyTable[row2][col1];
+    }
+  }
+
+  // ensure decrypted string is: all uppercase & contains only letter characters & excludes 'X'
+  plainText = plainText
+    .toUpperCase()
+    .replace(/[^A-Z]/g, "")
+    .replace(/X/g, "");
+
+  return plainText;
+}
+
+// RUNNING THE ALGORITHM!
+const cipherText = "IKEWENENXLNQLPZSLERUMRHEERYBOFNEINCHCV";
+const key = "SUPERSPY";
+const plainText = decryptCipherText(cipherText, key);
+console.log(plainText);
+
+// ADDITIONAL SAMPLE TEST CASES:
+// console.log(generateKeyTable("monarchy"));
+// console.log(generateKeyTable("playfair example"));
+
+// console.log(decryptCipherText("gatlmzclrqtx", "SUPERSPY"));
+// console.log(decryptCipherText("gatlmzclrqtx", "monarchy"));


### PR DESCRIPTION
## Description

This PR contains the solution for decrypting the cipherText into plainText. 

The solution consists of:
1. Generating the 5*5 `keytable`
2. Decrypting the `cipherText` using the `keytable` and supplied `key`.

Below:
* <a href="#techDetails">Technical Details</a>
* <a href="#Screenshots">Screenshots</a>
* <a href="#Additional">Additional Thought Processes + Rationale</a>
   * <a href="#rationale">Rationale for representing the 5x5 `keytable` as a 2D vs. 1D arra:</a>
   * <a href="#altGenMethods">Alternate key generation methods</a>
   * <a href="#future">Future Improvement Ideas</a>

<h2 id="techDetails"> Technical Details</h2>

Function `generateKeyTable`:
  - The 5*5 table must not contain duplicate letters or non-letter characters
  - All letters in the table must be uppercase
  - The function omits letters `"J", "Q", "I"` as specified in [these instructions](https://en.wikipedia.org/wiki/Playfair_cipher#:~:text=usually%20omitting%20%22J%22%20or%20%22Q%22%20to%20reduce%20the%20alphabet%20to%20fit%3B%20other%20versions%20put%20both%20%22I%22%20and%20%22J%22%20in%20the%20same%20space).

Function `decryptCipherText`:

- Decrypts the cipher text as specified in [these instructions](https://en.wikipedia.org/wiki/Playfair_cipher#:~:text=If%20the%20letters,the%20plaintext%20pair.). The following is a 'pseudo-code' overview:
```
  For each digram, obtain the keyTable row and col of the 2 letters indiivdually.
  - if (col1 === col2), replace each letter with the letter ABOVE it (wrapping index 0 --> 4)
      - ie. letter1: keyTable[row1][(col1 + 4) % 5] & letter2: keyTable[row2][(col2 + 4) % 5]
  - if (row1 === row2), replace each letter with the letter to its LEFT (wrapping index 0 --> 4)
      - ie. letter1: keyTable[(row1 + 4) % 5][col1] & letter2: keyTable[(row2 + 4) % 5][col2]
  - if neither, swap the columns of the 2 letters
      - ie. letter1: keyTable[row1][col2] & letter2: keyTable[row2][col1]
```

Function `getLetterRowCol`:
- A `helper/util function` to easily access the `row` and `col` of a letter in `keyTable`

<h2 id="Screenshots"> Screenshots</h2>

![SHOPIFY](https://github.com/Shopify/eng-internship-challenge/assets/121129755/00f2e07a-2206-40d3-826c-c58f46bfdef1)


<h2 id="Additional"> Additional Thought Processes + Rationale</h2>

<h3 id="rationale">Rationale for representing the 5x5 `keytable` as a 2D vs. 1D array:</h3>

  - 2D array is more intuitive to visualize and access
  - Does not rely on math (ie. modulus) to denote element indices
  - 2D array is more difficult to populate when generating `keytable` (looping vs. appending via .push())

  However, a 2D array was chosen since the `keytable` is generated only once yet referenced indexing multiple times.

<h3 id="altGenMethods">Alternate key generation methods:</h3>
* an alternative way to uppercase all letters is to manipulate the ASCII
* an alternative way to remove duplicates is to loop through and compare consecutive letters
* an alternative way to regex-removing non-letter characters is to check the ASCII letter range

<h3 id="future">Future Improvement Ideas:</h3>

* Be able to pass in a `keyTable` as an argument to `decryptCipherText` ==> provides flexibility for how user wants to define `keyTable`. 
   * Would also need to add "incompatible `keytable`" error handling
