### PR TITLE
ci(si-2496): Migrate to shop/setup-python-action

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,7 +18,7 @@ jobs:
         uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
 
       - name: Set up Python
-        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        uses: shop/setup-python-action@main
         with:
           python-version: '3.8'  # Specify the Python version here
 


### PR DESCRIPTION
Hey there, we are mitigating #si-2496-remediation 

We expect JavaScript and Python to migrate immediately based on [this recent annoucement](https://my.slack.com/archives/C0Q0DSZR8/p1775767510960779) in [#dev-up][dev-up]

This PR is a best-effort attempt to migrate for you!

* :green_heart: If this passes CI and we think it is a trivial change, we may merge this for you.
* :broken_heart: If this doesn't pass CI or we think it's a non-trivial change, feel free to take over ownership, add commits to it, and do what it takes to merge it.
* :hammer_and_pick: If you have already mitigated it, or are working on it separately, feel free to close this PR with a comment referencing the other PR.

If you need help, reach out in [#dev-up][dev-up]

[dev-up]: https://slack.com/archives/C0Q0DSZR8